### PR TITLE
Elaborated readme.md on build, usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,11 +22,24 @@ Dependency
 ----------------
 1. rasm2 in radare2
 2. unicorn-engine/unicorn
+3. golang (https://golang.org/doc/install)
 3. that's all!
 
 Build From Source
 ----------------
 1. install radare2
-2. install unicore and golang bindings
-3. build this project
+2. install unicorn (https://github.com/unicorn-engine/unicorn)
+3. install golang (https://golang.org/doc/install)
+4. build this project
 
+Build
+----------------
+1. go get -u github.com/c-bata/go-prompt
+2. go get -u github.com/unicorn-engine/unicorn/bindings/go/unicorn
+3. cd $GOROOT/
+4. go build \*.go
+
+Run
+----------------
+./8086 -a x86   #32bit mode
+./8086 -a x64   #64bit mode (default, even on x86)


### PR DESCRIPTION
Elaborated on building and usage.
Older x32bit distros may have outdated golang with deprecated references ; advised to download newest versoin and compile if necessary, however comes with prebuilt binaries already so just need to download and configure $GOPATH and $GOROOT env vars.
asm-cli binary defaults to x64bit views by default; esoteric usage instructions demystified to invoke as x32bit.
32bit system but tries using x64bit registers, addressing by default:
![image](https://user-images.githubusercontent.com/6711025/35772996-07cd0cb8-08fb-11e8-9a72-a1a279f095f0.png)
![image](https://user-images.githubusercontent.com/6711025/35773027-83673b96-08fb-11e8-9e7a-c52d80f710d5.png)

